### PR TITLE
Escape special characters inside alert name

### DIFF
--- a/src/main/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapper.java
+++ b/src/main/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapper.java
@@ -60,7 +60,8 @@ public class MenuCallbackMapper {
         if (!userAlerts.isEmpty()) {
             StringBuilder text = new StringBuilder("Ваши алерты:\n");
             userAlerts.forEach(userAlert -> text.append("*id:* ").append(userAlert.getId())
-                    .append("\n*Название:* ").append(userAlert.getName())
+                    .append("\n*Название:* ")
+                    .append(escapeSpecialCharacters(userAlert.getName()))
                     .append("\n"));
             message.setText(text.toString());
             message.setParseMode("MarkdownV2");
@@ -92,5 +93,14 @@ public class MenuCallbackMapper {
         message.setText(SELECT_ACTION.getText());
         message.setReplyMarkup(buildMainInlineKeyboardMarkup());
         return message;
+    }
+
+    private String escapeSpecialCharacters(String message) {
+        return message
+                .replace("_", "\\_")
+                .replace("*", "\\*")
+                .replace("[", "\\[")
+                .replace("`", "\\`")
+                .replace(".", "\\.");
     }
 }


### PR DESCRIPTION
В названии алерта могут попадаться символы, которые телеграм просит экранировать (иначе пытается распарсить их как часть markdown-разметки и падает с ошибкой)