### PR TITLE
Ask user params by specific order

### DIFF
--- a/src/main/java/dev/vality/alert/tg/bot/constants/TextConstants.java
+++ b/src/main/java/dev/vality/alert/tg/bot/constants/TextConstants.java
@@ -16,6 +16,7 @@ public enum TextConstants {
     SELECT_ALERT("Выберите алерт"),
     ALERT_REMOVED("Алерт удален"),
     ALERTS_REMOVED("Алерты удалены"),
+    NO_ALERTS_FOUND("У вас нет созданных алертов"),
     DELETE_ALL_ALERTS("Удалить все алерты"),
     SELECT_PARAM_FROM_LIST("Выберите из списка параметр: "),
     ENTER_PARAM_TO_REPLY("Введите в ответе параметр: "),

--- a/src/main/java/dev/vality/alert/tg/bot/handler/CallbackHandler.java
+++ b/src/main/java/dev/vality/alert/tg/bot/handler/CallbackHandler.java
@@ -30,7 +30,7 @@ public class CallbackHandler implements CommonHandler<SendMessage> {
         return switch (MainMenu.valueOfCallbackData(callbackData)) {
             case CREATE_ALERT -> menuCallbackMapper.createAlertCallback(userId);
             case GET_ALL_ALERTS -> menuCallbackMapper.getAllAlertsCallback(userId);
-            case DELETE_ALERT -> menuCallbackMapper.deleteAlertCallback();
+            case DELETE_ALERT -> menuCallbackMapper.deleteAlertCallback(userId);
             case DELETE_ALL_ALERTS -> menuCallbackMapper.deleteAllAlertsCallback(userId);
             case RETURN_TO_MENU -> menuCallbackMapper.returnCallback();
             case CONFIGURE_PARAM -> parametersCallbackMapper.mapParametersCallback(callbackData, userId);

--- a/src/main/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapper.java
+++ b/src/main/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapper.java
@@ -72,18 +72,28 @@ public class MenuCallbackMapper {
         return message;
     }
 
-    public SendMessage deleteAlertCallback() {
+    public SendMessage deleteAlertCallback(long userId) throws TException {
         SendMessage message = new SendMessage();
-        message.setText(ENTER_ALERT_ID_FOR_REMOVED.getText());
-        message.setReplyMarkup(new ForceReplyKeyboard());
+        if (mayDayService.getUserAlerts(String.valueOf(userId)).isEmpty()) {
+            message.setText(NO_ALERTS_FOUND.getText());
+            message.setReplyMarkup(buildMainInlineKeyboardMarkup());
+        } else {
+            message.setText(ENTER_ALERT_ID_FOR_REMOVED.getText());
+            message.setReplyMarkup(new ForceReplyKeyboard());
+        }
+
         return message;
     }
 
     public SendMessage deleteAllAlertsCallback(long userId) throws TException {
         log.info("User {} delete all alerts", userId);
         SendMessage message = new SendMessage();
-        mayDayService.deleteAllAlerts(String.valueOf(userId));
-        message.setText(ALERTS_REMOVED.getText());
+        if (mayDayService.getUserAlerts(String.valueOf(userId)).isEmpty()) {
+            message.setText(NO_ALERTS_FOUND.getText());
+        } else {
+            mayDayService.deleteAllAlerts(String.valueOf(userId));
+            message.setText(ALERTS_REMOVED.getText());
+        }
         message.setReplyMarkup(buildMainInlineKeyboardMarkup());
         return message;
     }

--- a/src/main/java/dev/vality/alert/tg/bot/mapper/ParametersCallbackMapper.java
+++ b/src/main/java/dev/vality/alert/tg/bot/mapper/ParametersCallbackMapper.java
@@ -14,10 +14,7 @@ import org.apache.thrift.TException;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Component
 @RequiredArgsConstructor
@@ -32,6 +29,7 @@ public class ParametersCallbackMapper {
         AlertConfiguration alertConfiguration = mayDayService.getAlertConfiguration(callData);
         String alertId = alertConfiguration.getId();
         List<ParameterConfiguration> parameterConfigurations = alertConfiguration.getParameters();
+        parameterConfigurations.sort(ParameterConfiguration::compareTo);
         fillStateDataAndSave(userId, alertId, parameterConfigurations);
         parameterConfigurations.forEach(param -> convertParameterConfigurationsAndSave(alertId, param));
         return ParamKeyboardBuilder.buildParamKeyboard(

--- a/src/test/java/dev/vality/alert/tg/bot/handler/CallbackHandlerTest.java
+++ b/src/test/java/dev/vality/alert/tg/bot/handler/CallbackHandlerTest.java
@@ -9,6 +9,7 @@ import dev.vality.alert.tg.bot.mapper.ParametersCallbackMapper;
 import dev.vality.alert.tg.bot.service.MayDayService;
 import dev.vality.alerting.mayday.AlertConfiguration;
 import dev.vality.alerting.mayday.ParameterConfiguration;
+import dev.vality.alerting.mayday.UserAlert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static dev.vality.alert.tg.bot.TestObjectFactory.*;
-import static dev.vality.alert.tg.bot.constants.TextConstants.ALERTS_REMOVED;
-import static dev.vality.alert.tg.bot.constants.TextConstants.SELECT_ALERT;
+import static dev.vality.alert.tg.bot.constants.TextConstants.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,10 +49,12 @@ public class CallbackHandlerTest {
 
     @Test
     void testCallbackDeleteAllAlertsHandler() throws Exception {
+        when(mayDayService.getUserAlerts(any())).thenReturn(List.of(new UserAlert()));
         Update update = testUpdateDeleteAllCallback();
         SendMessage sendMessage = callbackHandler.handle(update, 123L);
         assertNotNull(sendMessage);
         assertEquals(ALERTS_REMOVED.getText(), sendMessage.getText());
+        verify(mayDayService, times(1)).getUserAlerts(any());
         verify(mayDayService, times(1)).deleteAllAlerts(any());
     }
 

--- a/src/test/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapperTest.java
+++ b/src/test/java/dev/vality/alert/tg/bot/mapper/MenuCallbackMapperTest.java
@@ -55,19 +55,39 @@ public class MenuCallbackMapperTest {
     }
 
     @Test
-    void testDeleteAlertCallback() {
-        SendMessage sendMessage = menuCallbackMapper.deleteAlertCallback();
+    void testDeleteAlertNoAlertsCallback() throws Exception {
+        SendMessage sendMessage = menuCallbackMapper.deleteAlertCallback(123L);
+        assertNotNull(sendMessage);
+        assertNotNull(sendMessage.getReplyMarkup());
+        assertEquals(NO_ALERTS_FOUND.getText(), sendMessage.getText());
+    }
+
+    @Test
+    void testDeleteAlertCallback() throws Exception {
+        when(mayDayService.getUserAlerts(any())).thenReturn(List.of(new UserAlert()));
+        SendMessage sendMessage = menuCallbackMapper.deleteAlertCallback(123L);
         assertNotNull(sendMessage);
         assertNotNull(sendMessage.getReplyMarkup());
         assertEquals(ENTER_ALERT_ID_FOR_REMOVED.getText(), sendMessage.getText());
+        verify(mayDayService, times(1)).getUserAlerts(any());
+    }
+
+    @Test
+    void testDeleteAllAlertsButNoAlertsCallback() throws Exception {
+        SendMessage sendMessage = menuCallbackMapper.deleteAllAlertsCallback(123L);
+        assertNotNull(sendMessage);
+        assertNotNull(sendMessage.getReplyMarkup());
+        assertEquals(NO_ALERTS_FOUND.getText(), sendMessage.getText());
     }
 
     @Test
     void testDeleteAllAlertsCallback() throws Exception {
+        when(mayDayService.getUserAlerts(any())).thenReturn(List.of(new UserAlert()));
         SendMessage sendMessage = menuCallbackMapper.deleteAllAlertsCallback(123L);
         assertNotNull(sendMessage);
         assertNotNull(sendMessage.getReplyMarkup());
         assertEquals(ALERTS_REMOVED.getText(), sendMessage.getText());
+        verify(mayDayService, times(1)).getUserAlerts(any());
     }
 
     @Test


### PR DESCRIPTION
сейчас параметры запрашиваются у пользователя в случайном порядке. Однако у каждого параметара есть `id`, по которому и следует сортировать их для порядка, в котором предлагать пользователю. Дефолтный `CompareTo` трифта делает как раз это.